### PR TITLE
Move script tag out of embedded check, for onetrust

### DIFF
--- a/src/partials/_head.html
+++ b/src/partials/_head.html
@@ -12,9 +12,10 @@
 <!-- Safari, you're the worst -->
 <meta name='format-detection' content='telephone=no'>
 
-<% if (!project.embedded) { %>
 <!-- GDPR compliance -->
-<script src="https://apps.npr.org/gdpr/gdprCompliance.js" async defer></script>
+<script src="https://apps.npr.org/gdpr/gdprCompliance.js"></script>
+
+<% if (!project.embedded) { %>
 
 <!-- BEGIN TWITTER SUMMARY CARD -->
 <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
Adds the GDPR/OneTrust script to all pages that pull in the `_head` partial. 

This doesn't affect the social share pages or customizer:
- https://github.com/nprapps/elections20-interactive/blob/master/src/_office_social.html
- https://github.com/nprapps/elections20-interactive/blob/master/src/_state_social.html
- https://github.com/nprapps/elections20-interactive/blob/master/src/customizer.html
